### PR TITLE
Fix 'UserProfile matching query does not exist.'

### DIFF
--- a/lizard_auth_server/views_api.py
+++ b/lizard_auth_server/views_api.py
@@ -17,7 +17,8 @@ from django.views.decorators.debug import sensitive_variables
 from django.views.generic.edit import FormView
 
 from lizard_auth_server import forms
-from lizard_auth_server.http import JsonResponse, JsonError
+from lizard_auth_server.http import JsonError, JsonResponse
+from lizard_auth_server.models import UserProfile
 from lizard_auth_server.views_sso import construct_user_data
 
 logger = logging.getLogger(__name__)
@@ -81,7 +82,10 @@ class AuthenticateUnsignedView(FormView):
             if not user.is_active:
                 return JsonError('User account is disabled')
             else:
-                profile = user.get_profile()
+                try:
+                    profile = user.get_profile()
+                except UserProfile.DoesNotExist:
+                    return JsonError('No access to this portal')
                 if profile.has_access(portal):
                     user_data = construct_user_data(profile=profile)
                     return JsonResponse({'user': user_data})
@@ -150,7 +154,10 @@ class AuthenticateView(FormView):
             if not user.is_active:
                 return JsonError('User account is disabled')
             else:
-                profile = user.get_profile()
+                try:
+                    profile = user.get_profile()
+                except UserProfile.DoesNotExist:
+                    return JsonError('No access to this portal')
                 if profile.has_access(portal):
                     user_data = construct_user_data(profile=profile)
                     return JsonResponse({'user': user_data})
@@ -212,7 +219,10 @@ class GetUserView(FormView):
             if not user.is_active:
                 return JsonError('User account is disabled')
             else:
-                profile = user.get_profile()
+                try:
+                    profile = user.get_profile()
+                except UserProfile.DoesNotExist:
+                    return JsonError('No access to this portal')
                 if profile.has_access(portal):
                     user_data = construct_user_data(profile=profile)
                     return JsonResponse({'user': user_data})
@@ -251,7 +261,10 @@ class GetUsersView(FormView):
     def get_users(self, portal):
         user_data = []
         for user in User.objects.select_related('userprofile'):
-            profile = user.get_profile()
+            try:
+                profile = user.get_profile()
+            except UserProfile.DoesNotExist:
+                continue
             if profile.has_access(portal):
                 user_data.append(construct_user_data(profile=profile))
         return JsonResponse({'users': user_data})

--- a/lizard_auth_server/views_sso.py
+++ b/lizard_auth_server/views_sso.py
@@ -27,7 +27,7 @@ from itsdangerous import URLSafeTimedSerializer
 import pytz
 
 from lizard_auth_server import forms
-from lizard_auth_server.models import Token
+from lizard_auth_server.models import Token, UserProfile
 from lizard_auth_server.views import ErrorMessageResponse
 
 logger = logging.getLogger(__name__)
@@ -188,7 +188,10 @@ class AuthorizeView(ProcessGetFormView):
             # login anyway
             return False
         # check whether the UserProfile object is related to this Portal
-        profile = self.request.user.get_profile()
+        try:
+            profile = self.request.user.get_profile()
+        except UserProfile.DoesNotExist:
+            return False
         return profile.has_access(self.token.portal)
 
     def success(self):


### PR DESCRIPTION
A user profile is not automatically created, so users without one may exist. The get_users(self, portal) function, which is used by other portals via lizard-auth-server's API, currently fails because of this.
