### PR TITLE
Byrman multiple domains

### DIFF
--- a/lizard_auth_server/models.py
+++ b/lizard_auth_server/models.py
@@ -62,7 +62,9 @@ class Portal(models.Model):
     allowed_domain = models.CharField(
         max_length=255,
         default='',
-        help_text='Allowed domain pattern for redirects using the ''next'' parameter.')
+        help_text=(
+            'Allowed domain suffix for redirects using the next parameter. '
+            'Multiple, whitespace-separated suffixes may be specified.'))
     redirect_url = models.CharField(
         max_length=255,
         help_text='URL used in the SSO redirection.')

--- a/lizard_auth_server/views_sso.py
+++ b/lizard_auth_server/views_sso.py
@@ -327,8 +327,20 @@ def get_next(form):
     return portal_redirect
 
 
-def domain_match(domain, pattern):
-    return domain.endswith(pattern)
+def domain_match(domain, suffix):
+    """Test if `domain` ends with `suffix`.
+
+    Args:
+       domain (str): a domain name.
+       suffix (str): a string the domain name should end with. Multiple
+         suffixes are possible and should be separated by whitespace,
+         for example: 'lizard.net ddsc.nl'.
+
+    Returns:
+       bool: True if domain ends with the specified suffix, False otherwise.
+
+    """
+    return domain.endswith(tuple(suffix.split()))
 
 
 class VerifyView(ProcessGetFormView):

--- a/lizard_auth_server/views_sso.py
+++ b/lizard_auth_server/views_sso.py
@@ -237,9 +237,12 @@ class AuthorizeView(ProcessGetFormView):
             'message': self.request.GET['message'],
             'key': self.request.GET['key'],
         }
-        params = urlencode([('next', '%s?%s' % (
-                                  reverse('lizard_auth_server.sso.authorize'),
-                                  urlencode(nextparams)))])
+        params = urlencode([(
+            'next',
+            '%s?%s' % (
+                reverse('lizard_auth_server.sso.authorize'),
+                urlencode(nextparams))
+        )])
         return '%s?%s' % (reverse('django.contrib.auth.views.login'), params)
 
     def form_valid_unauthenticated(self):


### PR DESCRIPTION
Currently, a domain name can only be tested for a single suffix: e.g. "lizard.net". This pull request makes it possible to specify multiple (white-space separated) suffixes.