### PR TITLE
A user arriving at the SSO server after being redirected there can now

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,21 @@ Changelog of lizard-auth-server
 1.8 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- A user arriving at the SSO server after being redirected there can now
+  use a "force_login" URL attribute. If the user is already logged in on
+  the SSO server, redirects are set up so that he will be logged in on
+  the site he was redirected from.
+
+  If he is not, then if force_login is True (the default, and the
+  old behaviour), then he will be forced to log in before being redirected
+  back.
+
+  If force_login is False, redirect the user back without logging in (to
+  lizard-auth-client's /sso/local_not_logged_in/ URL).
+
+  This enables a "attempt to auto-login if possible, but don't require it"
+  workflow that is sometimes helpful.
+
 
 
 1.7 (2016-06-14)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,17 +5,17 @@ Changelog of lizard-auth-server
 1.8 (unreleased)
 ----------------
 
-- A user arriving at the SSO server after being redirected there can now
-  use a "force_login" URL attribute. If the user is already logged in on
-  the SSO server, redirects are set up so that he will be logged in on
-  the site he was redirected from.
+- A user arriving at the SSO server after being redirected there can
+  now use a "return_unauthenticated" URL attribute. If the user is
+  already logged in on the SSO server, redirects are set up so that he
+  will be logged in on the site he was redirected from.
 
-  If he is not, then if force_login is True (the default, and the
-  old behaviour), then he will be forced to log in before being redirected
-  back.
+  If he is not, then if return_unauthenticated is False (the default,
+  and the old behaviour), then he will be forced to log in before
+  being redirected back.
 
-  If force_login is False, redirect the user back without logging in (to
-  lizard-auth-client's /sso/local_not_logged_in/ URL).
+  If return_unauthenticated, redirect the user back without logging in
+  (to lizard-auth-client's /sso/local_not_logged_in/ URL).
 
   This enables a "attempt to auto-login if possible, but don't require it"
   workflow that is sometimes helpful.

--- a/lizard_auth_server/models.py
+++ b/lizard_auth_server/models.py
@@ -54,7 +54,7 @@ class GenKey(object):
         self.field = field
 
     def __call__(self):
-        if isinstance(self.model, basestring):
+        if isinstance(self.model, str):
             ModelClass = get_model('lizard_auth_server', self.model)
             if not ModelClass:
                 raise Exception('Unknown model {}'.format(self.model))

--- a/lizard_auth_server/views_sso.py
+++ b/lizard_auth_server/views_sso.py
@@ -252,7 +252,7 @@ class AuthorizeView(ProcessGetFormView):
 
     def build_back_to_portal_url(self):
         """Redirect user back to the portal, without logging him in."""
-        return urljoin(self.domain, 'sso/local_not_logged_in') + '/'
+        return urljoin(self.domain, 'sso/local_not_logged_in/')
 
     def form_valid_unauthenticated(self, return_unauthenticated):
         """

--- a/lizard_auth_server/views_sso.py
+++ b/lizard_auth_server/views_sso.py
@@ -154,8 +154,8 @@ class AuthorizeView(ProcessGetFormView):
         except Token.DoesNotExist:
             return HttpResponseForbidden('Invalid request token')
         if self.check_token_timeout():
+            self.domain = get_domain(form)
             if self.request.user.is_authenticated():
-                self.domain = get_domain(form)
                 return self.form_valid_authenticated()
             return self.form_valid_unauthenticated(
                 form.cleaned_data.get('return_unauthenticated', False))

--- a/lizard_auth_server/views_sso.py
+++ b/lizard_auth_server/views_sso.py
@@ -216,7 +216,7 @@ class AuthorizeView(ProcessGetFormView):
         self.token.user = self.request.user
         self.token.save()
         # redirect user back to the portal
-        url = urljoin(self.domain, 'sso/local_login') + '/'
+        url = urljoin(self.domain, 'sso/local_login/')
         url = '%s?%s' % (url, urlencode({'message': message}))
         return HttpResponseRedirect(url)
 

--- a/lizard_auth_server/views_sso.py
+++ b/lizard_auth_server/views_sso.py
@@ -158,7 +158,7 @@ class AuthorizeView(ProcessGetFormView):
                 self.domain = get_domain(form)
                 return self.form_valid_authenticated()
             return self.form_valid_unauthenticated(
-                form.cleaned_data.get('force_login', True))
+                form.cleaned_data.get('return_unauthenticated', False))
         return self.token_timeout()
 
     def form_invalid(self, form):
@@ -254,15 +254,16 @@ class AuthorizeView(ProcessGetFormView):
         """Redirect user back to the portal, without logging him in."""
         return urljoin(self.domain, 'sso/local_not_logged_in') + '/'
 
-    def form_valid_unauthenticated(self, force_login):
+    def form_valid_unauthenticated(self, return_unauthenticated):
         """
-        Redirect user, to login page if force_login == True.
+        Redirect user, to login page if return_unauthenticated == False.
         """
-        if force_login:
-            return HttpResponseRedirect(self.build_login_url())
-        else:
+        if return_unauthenticated:
             # Return the unauthenticated user back to the portal.
             return HttpResponseRedirect(self.build_back_to_portal_url())
+        else:
+            # Typical situation -- force the user to login.
+            return HttpResponseRedirect(self.build_login_url())
 
 
 def construct_user_data(user=None, profile=None):


### PR DESCRIPTION
use a "return_unauthorized" URL attribute. If the user is already logged in on
the SSO server, redirects are set up so that he will be logged in on
the site he was redirected from.

If he is not, then if return_unauthorized is False (the default, and the old
behaviour), then he will be forced to log in before being redirected
back.

If return_unauthorized is True, redirect the user back without logging in (to
lizard-auth-client's /sso/local_not_logged_in/ URL).

This enables a "attempt to auto-login if possible, but don't require it"
workflow that is sometimes helpful.