### PR TITLE
Duplicate username: more explicit + more logging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of lizard-auth-server
 2.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Added more logging and made 'duplicate username' error, when creating a
+  user, more explicit.
 
 
 2.5 (2016-09-23)

--- a/lizard_auth_server/forms.py
+++ b/lizard_auth_server/forms.py
@@ -98,7 +98,8 @@ class JWTDecryptForm(forms.Form):
         if 'key' not in original_cleaned_data:
             raise ValidationError('No SSO key')
         try:
-            portal = Portal.objects.get(sso_key=original_cleaned_data['key'])
+            portal = Portal.objects.get(
+                sso_key=original_cleaned_data['key'])
         except Portal.DoesNotExist:
             raise ValidationError('Invalid SSO key')
         try:

--- a/lizard_auth_server/tests/test_views_api_v2.py
+++ b/lizard_auth_server/tests/test_views_api_v2.py
@@ -239,3 +239,23 @@ class TestNewUserView(TestCase):
         form.cleaned_data = self.user_data
         result = self.view.form_valid(form)
         self.assertEquals(200, result.status_code)
+
+    def test_duplicate_username(self):
+        factories.UserF(username='pietje',
+                        email='nietpietje@example.com')
+        form = Mock()
+        form.cleaned_data = self.user_data
+        self.assertRaises(ValidationError,
+                          self.view.form_valid,
+                          form)
+
+    def test_duplicate_username_http_response(self):
+        client = Client()
+        params = {'username': 'pietje',
+                  'email': 'nietpietje@example.com',
+                  'first_name': 'pietje',
+                  'last_name': 'pietje',
+        }
+        response = client.post(
+            reverse('lizard_auth_server.api_v2.new_user'), params)
+        self.assertEquals(400, response.status_code)

--- a/lizard_auth_server/tests/test_views_api_v2.py
+++ b/lizard_auth_server/tests/test_views_api_v2.py
@@ -28,6 +28,8 @@ class TestStartView(TestCase):
 
 class TestCheckCredentialsView(TestCase):
     def setUp(self):
+        self.sso_key = 'sso key'
+        factories.PortalF.create(sso_key=self.sso_key)
         self.view = views_api_v2.CheckCredentialsView()
         self.request_factory = RequestFactory()
         self.some_request = self.request_factory.get('/some/url/')
@@ -51,7 +53,8 @@ class TestCheckCredentialsView(TestCase):
 
     def test_valid_login(self):
         form = Mock()
-        form.cleaned_data = {'username': self.username,
+        form.cleaned_data = {'iss': self.sso_key,
+                             'username': self.username,
                              'password': self.password}
 
         result = self.view.form_valid(form)
@@ -59,7 +62,8 @@ class TestCheckCredentialsView(TestCase):
 
     def test_invalid_login(self):
         form = Mock()
-        form.cleaned_data = {'username': 'pietje',
+        form.cleaned_data = {'iss': self.sso_key,
+                             'username': 'pietje',
                              'password': 'ikkanniettypen'}
         self.assertRaises(PermissionDenied, self.view.form_valid, form)
 
@@ -205,9 +209,12 @@ class TestLogoutViewV2(TestCase):
 class TestNewUserView(TestCase):
     def setUp(self):
         self.view = views_api_v2.NewUserView()
+        sso_key = 'sso key'
+        factories.PortalF.create(sso_key=sso_key)
         self.request_factory = RequestFactory()
         self.some_request = self.request_factory.get('/some/url/')
-        self.user_data = {'username': 'pietje',
+        self.user_data = {'iss': sso_key,
+                          'username': 'pietje',
                           'email': 'pietje@klaasje.test.com',
                           'first_name': 'pietje',
                           'last_name': 'klaasje'}

--- a/lizard_auth_server/views_api_v2.py
+++ b/lizard_auth_server/views_api_v2.py
@@ -146,12 +146,20 @@ class CheckCredentialsView(FormInvalidMixin, FormMixin, ProcessFormView):
             (not 'password' in form.cleaned_data)):
             raise ValidationError(
                 "username and/or password are missing from the JWT message")
+        portal = Portal.objects.get(sso_key=form.cleaned_data['iss'])
         # Verify the username/password
         user = django_authenticate(username=form.cleaned_data.get('username'),
                                    password=form.cleaned_data.get('password'))
         if not user:
+            logger.info(
+                "Credentials for %s don't match (requested by portal %s)",
+                form.cleaned_data.get('username'),
+                portal)
             raise PermissionDenied("Login failed")
 
+        logger.info(
+            "Credentials for user %s checked succesfully for portal %s",
+            user, portal)
         user_data = construct_user_data(user=user)
         return HttpResponse(json.dumps({'user': user_data}),
                             content_type='application/json')
@@ -167,6 +175,8 @@ class LoginView(FormInvalidMixin, ProcessGetFormView):
         out by extracting the contents. Then depending on whether the user is
         authenticated, we call :meth:`.form_valid_and_authenticated` or
         :meth:`.form_valid_but_unauthenticated`.
+
+        We set ``self.portal`` so that it can be used in logging.
 
         Args:
             form: A :class:`lizard_auth_server.forms.JWTDecryptForm`
@@ -224,8 +234,13 @@ class LoginView(FormInvalidMixin, ProcessGetFormView):
 
         """
         if not self.unauthenticated_is_ok_url:
+            logger.info("User needs to log in first for %s: redirecting",
+                        self.portal)
             return HttpResponseRedirect(self.our_login_page_url())
         else:
+            logger.info(
+                "User isn't logged in, but that's OK. Redirecting back to %s",
+                self.portal)
             return HttpResponseRedirect(self.unauthenticated_is_ok_url)
 
     def form_valid_and_authenticated(self):
@@ -241,7 +256,10 @@ class LoginView(FormInvalidMixin, ProcessGetFormView):
                                     self.portal.sso_secret,
                                     algorithm=JWT_ALGORITHM)
         params = {'message': signed_message}
-        url_with_params = '%s?%s' % (self.login_success_url, urlencode(params))
+        url_with_params = '%s?%s' % (self.login_success_url,
+                                     urlencode(params))
+        logger.info("User %s is logged in: sending user info back to %s",
+                    self.request.user, self.portal)
         return HttpResponseRedirect(url_with_params)
 
 
@@ -303,6 +321,8 @@ class LogoutView(FormInvalidMixin, ProcessGetFormView):
                                urlencode(params_for_logout_redirect_back_view))
             })
         url = '%s?%s' % (djangos_logout_url, params)
+        logger.debug("Redirecting user %s to django's logout page...",
+                     self.request.user)
         return HttpResponseRedirect(url)
 
 
@@ -333,6 +353,10 @@ class LogoutRedirectBackView(FormInvalidMixin, ProcessGetFormView):
         # JWT message contents is the same as in LogoutView and has been
         # checked there. So we don't need to check for a missing logout_url
         # parameter.
+        portal = Portal.objects.get(sso_key=form.cleaned_data['iss'])
+        logger.info(
+            "User is logged out. Redirecting to logout page of %s itself",
+            portal)
         return HttpResponseRedirect(form.cleaned_data['logout_url'])
 
 
@@ -385,6 +409,7 @@ class NewUserView(FormInvalidMixin, FormMixin, ProcessFormView):
                 an 'error 400' ought to be equivalent to 'duplicate username'.
 
         """
+        portal = Portal.objects.get(sso_key=form.cleaned_data['iss'])
         # The JWT message is validated; now check the message's contents.
         mandatory_keys = ['username', 'email', 'first_name', 'last_name']
         for key in mandatory_keys:
@@ -402,6 +427,8 @@ class NewUserView(FormInvalidMixin, FormMixin, ProcessFormView):
                     "More than one user found for '%s', returning the first",
                     form.cleaned_data['email'])
             user = matching_users[0]
+            logger.info("Found existing user %s, giving that one to %s",
+                        user, portal)
 
         if not user:
             try:
@@ -415,6 +442,8 @@ class NewUserView(FormInvalidMixin, FormMixin, ProcessFormView):
                 logger.exception("Probably duplicate username")
                 raise ValidationError("Duplicate username")
             status_code = 201  # Created
+            logger.info("Created user %s as requested by portal %s",
+                        user, portal)
             logger.warn(
                 "We just created a user '%s' with password '%s': TODO!!!",
                 user.username,

--- a/lizard_auth_server/views_api_v2.py
+++ b/lizard_auth_server/views_api_v2.py
@@ -14,7 +14,6 @@ from django.core.urlresolvers import reverse
 from django.db.utils import IntegrityError
 from django.forms import ValidationError
 from django.http import HttpResponse
-from django.http import HttpResponseBadRequest
 from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt


### PR DESCRIPTION
Meer logging toegevoegd.

Duidelijk gemaakt dat 'duplicate username' een error 400 oplevert en dat dat een goede check is. Inclusief test en explicietere foutmelding.