### PR TITLE
find-user API endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ Changelog of lizard-auth-server
 - Bugfix: email lookup, when looking for users in the V2 API, is now
   case-insensitive.
 
+- Added ``/api2/find_user/`` in addition to ``/api2/new_user/``. This new view
+  only needs an email address and then looks up a matching user. So you don't
+  need to pass first/last/username. It will only look, though, it won't
+  create.
+
 
 2.12 (2016-10-19)
 -----------------

--- a/doc/source/explanation_api.rst
+++ b/doc/source/explanation_api.rst
@@ -38,6 +38,18 @@ The call returns the same dict as the api method above.
 See :class:`lizard_auth_server.views_api_v2.NewUserView`
 
 
+``/api2/find_user/``
+------------------------------
+
+Use it to find a user on the SSO based on email. It returns the first one
+found. If not found, a 404 is returned.
+
+The call returns the same dict as the api method above. Note: this view
+doesn't change the database, so you can call it with a ``GET``.
+
+See :class:`lizard_auth_server.views_api_v2.FindUserView`
+
+
 ``/api2/organisations/``
 ------------------------
 

--- a/doc/source/reference_api.rst
+++ b/doc/source/reference_api.rst
@@ -12,3 +12,6 @@ API reference
 
 .. autoclass:: lizard_auth_server.views_api_v2.NewUserView
    :members:
+
+.. autoclass:: lizard_auth_server.views_api_v2.FindUserView
+   :members:

--- a/lizard_auth_server/tests/test_views_api_v2.py
+++ b/lizard_auth_server/tests/test_views_api_v2.py
@@ -640,12 +640,6 @@ class TestFindUserView(TestCase):
         self.user_data = {'iss': self.sso_key,
                           'email': 'pietje@klaasje.test.com'}
 
-    def test_disallowed_get(self):
-        client = Client()
-        result = client.get(
-            reverse('lizard_auth_server.api_v2.find_user'))
-        self.assertEquals(405, result.status_code)
-
     def test_exiting_user(self):
         factories.UserF(email='pietje@klaasje.test.com')
         form = mock.Mock()
@@ -665,3 +659,19 @@ class TestFindUserView(TestCase):
         form.cleaned_data = self.user_data
         result = self.view.form_valid(form)
         self.assertEquals(404, result.status_code)
+
+    def test_get_allowed(self):
+        client = Client()
+        result = client.get(
+            reverse('lizard_auth_server.api_v2.find_user'))
+        # Status code should be 400 because of an invalid form. It should not
+        # be 405 because of a wrong method.
+        self.assertEquals(400, result.status_code)
+
+    def test_post_allowed(self):
+        client = Client()
+        result = client.post(
+            reverse('lizard_auth_server.api_v2.find_user'))
+        # Status code should be 400 because of an invalid form. It should not
+        # be 405 because of a wrong method.
+        self.assertEquals(400, result.status_code)

--- a/lizard_auth_server/tests/test_views_api_v2.py
+++ b/lizard_auth_server/tests/test_views_api_v2.py
@@ -626,3 +626,42 @@ class TestOrganisationsView(TestCase):
         response = self.client.get('/api2/organisations/',
                                    self.jwt_params)
         self.assertIn('Neuwitz', str(response.content))
+
+
+class TestFindUserView(TestCase):
+
+    def setUp(self):
+        self.view = views_api_v2.FindUserView()
+        self.sso_key = 'sso key'
+        factories.PortalF.create(sso_key=self.sso_key)
+        self.request_factory = RequestFactory()
+        self.some_request = self.request_factory.get(
+            'http://some.site/some/url/')
+        self.user_data = {'iss': self.sso_key,
+                          'email': 'pietje@klaasje.test.com'}
+
+    def test_disallowed_get(self):
+        client = Client()
+        result = client.get(
+            reverse('lizard_auth_server.api_v2.find_user'))
+        self.assertEquals(405, result.status_code)
+
+    def test_exiting_user(self):
+        factories.UserF(email='pietje@klaasje.test.com')
+        form = mock.Mock()
+        form.cleaned_data = self.user_data
+        result = self.view.form_valid(form)
+        self.assertEquals(200, result.status_code)
+
+    def test_exiting_user_different_case(self):
+        factories.UserF(email='Pietje@Klaasje.Test.Com')
+        form = mock.Mock()
+        form.cleaned_data = self.user_data
+        result = self.view.form_valid(form)
+        self.assertEquals(200, result.status_code)
+
+    def test_nonexiting_user(self):
+        form = mock.Mock()
+        form.cleaned_data = self.user_data
+        result = self.view.form_valid(form)
+        self.assertEquals(404, result.status_code)

--- a/lizard_auth_server/tests/test_views_api_v2.py
+++ b/lizard_auth_server/tests/test_views_api_v2.py
@@ -667,11 +667,3 @@ class TestFindUserView(TestCase):
         # Status code should be 400 because of an invalid form. It should not
         # be 405 because of a wrong method.
         self.assertEquals(400, result.status_code)
-
-    def test_post_allowed(self):
-        client = Client()
-        result = client.post(
-            reverse('lizard_auth_server.api_v2.find_user'))
-        # Status code should be 400 because of an invalid form. It should not
-        # be 405 because of a wrong method.
-        self.assertEquals(400, result.status_code)

--- a/lizard_auth_server/urls.py
+++ b/lizard_auth_server/urls.py
@@ -107,6 +107,9 @@ urlpatterns = patterns(
     url(r'^api2/new_user/$',
         views_api_v2.NewUserView.as_view(),
         name='lizard_auth_server.api_v2.new_user'),
+    url(r'^api2/find_user/$',
+        views_api_v2.FindUserView.as_view(),
+        name='lizard_auth_server.api_v2.find_user'),
     # Views for visitors
     url(r'^api2/login/$',
         views_api_v2.LoginView.as_view(),

--- a/lizard_auth_server/views_api_v2.py
+++ b/lizard_auth_server/views_api_v2.py
@@ -715,12 +715,17 @@ class FindUserView(FormInvalidMixin, FormMixin, ProcessFormView):
     GET is allowed as it doesn't alter the database.
 
     """
+    http_method_names = ['get', 'post']
     form_class = forms.JWTDecryptForm
 
     @method_decorator(csrf_exempt)
     def dispatch(self, request, *args, **kwargs):
         return super(FindUserView, self).dispatch(
             request, *args, **kwargs)
+
+    def get(self, request, *args, **kwargs):
+        # Just handle the form as usual.
+        return self.post(request, *args, **kwargs)
 
     def form_valid(self, form):
         """Return user data of an existing user, if found

--- a/lizard_auth_server/views_api_v2.py
+++ b/lizard_auth_server/views_api_v2.py
@@ -707,7 +707,7 @@ class OrganisationsView(FormInvalidMixin, ProcessGetFormView):
                             content_type='application/json')
 
 
-class FindUserView(FormInvalidMixin, FormMixin, ProcessFormView):
+class FindUserView(FormInvalidMixin, ProcessGetFormView):
     """View to return an existing user based on email address
 
     The email adress is passed in a JWT signed form.
@@ -717,15 +717,6 @@ class FindUserView(FormInvalidMixin, FormMixin, ProcessFormView):
     """
     http_method_names = ['get', 'post']
     form_class = forms.JWTDecryptForm
-
-    @method_decorator(csrf_exempt)
-    def dispatch(self, request, *args, **kwargs):
-        return super(FindUserView, self).dispatch(
-            request, *args, **kwargs)
-
-    def get(self, request, *args, **kwargs):
-        # Just handle the form as usual.
-        return self.post(request, *args, **kwargs)
 
     def form_valid(self, form):
         """Return user data of an existing user, if found


### PR DESCRIPTION
The idea: `NewUserView` creates a new user and returns an existing one if found based on the email address. `FindUserView` will only look for existing ones. Advantage: you only have to pass the email address, not first/last/username.