### PR TITLE
JWT form errors in API requests now return txt message instead of html

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog of lizard-auth-server
 2.15 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- JWT form errors in API requests now return a text message instead of
+  html. So JWT errors now also return a meaningful HTTP response to the
+  client.
 
 
 2.14 (2016-12-07)

--- a/lizard_auth_server/tests/test_views_api_v2.py
+++ b/lizard_auth_server/tests/test_views_api_v2.py
@@ -657,3 +657,11 @@ class TestFindUserView(TestCase):
         # Status code should be 400 because of an invalid form. It should not
         # be 405 because of a wrong method.
         self.assertEquals(400, result.status_code)
+
+    def test_useful_api_error_response(self):
+        client = Client()
+        result = client.get(
+            reverse('lizard_auth_server.api_v2.find_user'))
+        # The returned content should be a textual message about the jwt
+        # error, not a html page.
+        self.assertNotIn('html', str(result.content))


### PR DESCRIPTION
So: regular error messages ("duplicate user") worked fine, they returned textual messages. But jwt errors would return a html view instead of text because of the `FormInvalidMixin`. I've added a second one that returns text, optimized for the JWT form.