### PR TITLE
Make organisations searchable by unique_id.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of lizard-auth-server
 2.22 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Make organisations also searchable by unique_id in the Django admin.
 
 
 2.21 (2018-03-16)

--- a/lizard_auth_server/admin.py
+++ b/lizard_auth_server/admin.py
@@ -258,7 +258,7 @@ class PortalAdmin(admin.ModelAdmin):
 
 class OrganisationAdmin(admin.ModelAdmin):
     model = models.Organisation
-    search_fields = ['name']
+    search_fields = ['name', 'unique_id']
     list_display = ['name', 'num_user_profiles', 'num_roles']
     readonly_fields = ['unique_id']
     inlines = [OrganisationRoleInline]


### PR DESCRIPTION
Got this error message in one of our applications, but there's no easy way of finding organisations by uuid:

User does not have the run_simulation permission for organisation 1f6655ea527449d6b3d074217eac4024