### PR TITLE
AWS Finishing touches (edit_profile, forgot/change password, user existence check)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ Changelog of lizard-auth-server
 2.28 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Disabled the edit_profile view.
+
+- Use cognito for changing passwords (Change password and Forgot password).
+  This feature is only switched on if the setting AWS_ACCESS_KEY_ID is
+  configured.
 
 
 2.27 (2021-01-25)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Changelog of lizard-auth-server
   This feature is only switched on if the setting AWS_ACCESS_KEY_ID is
   configured.
 
+- Add a User pre_save signal handler that checks if a user exists in Cognito.
+
 
 2.27 (2021-01-25)
 -----------------

--- a/lizard_auth_server/backends.py
+++ b/lizard_auth_server/backends.py
@@ -43,6 +43,17 @@ class CognitoUser(Cognito):
         },
     )
 
+    @classmethod
+    def from_username(cls, username):
+        return cls(
+            settings.COGNITO_USER_POOL_ID,
+            settings.COGNITO_APP_ID,
+            access_key=getattr(settings, "AWS_ACCESS_KEY_ID", None),
+            secret_key=getattr(settings, "AWS_SECRET_ACCESS_KEY", None),
+            client_secret=getattr(settings, "COGNITO_APP_SECRET", None),
+            username=username,
+        )
+
     def get_user_obj(self, username=None, attribute_list=[], metadata={}, attr_map={}):
         user_attrs = cognito_to_dict(attribute_list, CognitoUser.COGNITO_ATTR_MAPPING)
         django_fields = [f.name for f in CognitoUser.user_class._meta.get_fields()]
@@ -65,6 +76,14 @@ class CognitoUser(Cognito):
 
         return user
 
+    def admin_set_user_password(self, password):
+        self.client.admin_set_user_password(
+            UserPoolId=self.user_pool_id,
+            Username=self.username,
+            Permanent=True,
+            Password=password,
+        )
+
 
 class CognitoBackend(ModelBackend):
 
@@ -81,14 +100,7 @@ class CognitoBackend(ModelBackend):
         :param password: Cognito password
         :return: returns User instance of AUTH_USER_MODEL or None
         """
-        cognito_user = CognitoUser(
-            settings.COGNITO_USER_POOL_ID,
-            settings.COGNITO_APP_ID,
-            access_key=getattr(settings, "AWS_ACCESS_KEY_ID", None),
-            secret_key=getattr(settings, "AWS_SECRET_ACCESS_KEY", None),
-            client_secret=getattr(settings, "COGNITO_APP_SECRET", None),
-            username=username,
-        )
+        cognito_user = CognitoUser.from_username(username)
         try:
             cognito_user.admin_authenticate(password)
             # ^^^ This uses ADMIN_NO_SRP_AUTH, but that's the old name for

--- a/lizard_auth_server/backends.py
+++ b/lizard_auth_server/backends.py
@@ -77,12 +77,27 @@ class CognitoUser(Cognito):
         return user
 
     def admin_set_user_password(self, password):
+        """Set the user's password"""
         self.client.admin_set_user_password(
             UserPoolId=self.user_pool_id,
             Username=self.username,
             Permanent=True,
             Password=password,
         )
+
+    def admin_user_exists(self):
+        """Return whether a user with username == self.username exists"""
+        try:
+            self.client.admin_get_user(
+                UserPoolId=self.user_pool_id, Username=self.username
+            )
+        except (Boto3Error, ClientError) as e:
+            error_code = e.response["Error"]["Code"]
+            if error_code == CognitoBackend.USER_NOT_FOUND_ERROR_CODE:
+                return False
+            else:
+                raise
+        return True
 
 
 class CognitoBackend(ModelBackend):

--- a/lizard_auth_server/forms.py
+++ b/lizard_auth_server/forms.py
@@ -9,12 +9,13 @@ from django.forms import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from itsdangerous import BadSignature
 from itsdangerous import URLSafeTimedSerializer
+from lizard_auth_server.backends import CognitoBackend
+from lizard_auth_server.backends import CognitoUser
 from lizard_auth_server.models import BILLING_ROLE
 from lizard_auth_server.models import Organisation
 from lizard_auth_server.models import Portal
 from lizard_auth_server.models import THREEDI_PORTAL
 from lizard_auth_server.models import UserProfile
-from lizard_auth_server.backends import CognitoUser, CognitoBackend
 
 import jwt
 
@@ -188,13 +189,16 @@ class SetPasswordMixin:
             return super().clean_old_password()
 
         old_password = self.cleaned_data["old_password"]
-        if CognitoBackend().authenticate(
-            username=self.user.username, password=old_password
-        ) is None:
+        if (
+            CognitoBackend().authenticate(
+                username=self.user.username, password=old_password
+            )
+            is None
+        ):
             # Copy of the error in the super() call
             raise forms.ValidationError(
-                self.error_messages['password_incorrect'],
-                code='password_incorrect',
+                self.error_messages["password_incorrect"],
+                code="password_incorrect",
             )
 
         return old_password
@@ -205,8 +209,7 @@ class SetPasswordMixin:
         return password1
 
     def save(self, commit=True):
-        """Override the builtin SetPassword and send the password to Cognito
-        """
+        """Override the builtin SetPassword and send the password to Cognito"""
         # Old behaviour if AWS is not setup (local situations)
         if not getattr(settings, "AWS_ACCESS_KEY_ID", None):
             return super().save(commit=commit)

--- a/lizard_auth_server/forms.py
+++ b/lizard_auth_server/forms.py
@@ -14,6 +14,7 @@ from lizard_auth_server.models import Organisation
 from lizard_auth_server.models import Portal
 from lizard_auth_server.models import THREEDI_PORTAL
 from lizard_auth_server.models import UserProfile
+from lizard_auth_server.backends import CognitoUser, CognitoBackend
 
 import jwt
 
@@ -174,22 +175,55 @@ class AuthenticateUnsignedForm(forms.Form):
         return data
 
 
-class PasswordChangeForm(authforms.PasswordChangeForm):
-    """Used to verify whether the new password is secure."""
+class SetPasswordMixin:
+    """Used to check whether the new password is secure and for the AWS
+    coupling."""
+
+    def clean_old_password(self):
+        """
+        Validates that the old_password field is correct.
+        """
+        # Old behaviour if AWS is not setup (local situations)
+        if not getattr(settings, "AWS_ACCESS_KEY_ID", None):
+            return super().clean_old_password()
+
+        old_password = self.cleaned_data["old_password"]
+        if CognitoBackend().authenticate(
+            username=self.user.username, password=old_password
+        ) is None:
+            # Copy of the error in the super() call
+            raise forms.ValidationError(
+                self.error_messages['password_incorrect'],
+                code='password_incorrect',
+            )
+
+        return old_password
 
     def clean_new_password1(self):
         password1 = self.cleaned_data.get("new_password1")
         validate_password(password1)
         return password1
 
+    def save(self, commit=True):
+        """Override the builtin SetPassword and send the password to Cognito
+        """
+        # Old behaviour if AWS is not setup (local situations)
+        if not getattr(settings, "AWS_ACCESS_KEY_ID", None):
+            return super().save(commit=commit)
 
-class SetPasswordForm(authforms.SetPasswordForm):
-    """Used to verify whether the new password is secure."""
+        if commit:
+            password = self.cleaned_data["new_password1"]
+            cognito_user = CognitoUser.from_username(self.user.username)
+            cognito_user.admin_set_user_password(password)
+        return self.user
 
-    def clean_new_password1(self):
-        password1 = self.cleaned_data.get("new_password1")
-        validate_password(password1)
-        return password1
+
+class PasswordChangeForm(SetPasswordMixin, authforms.PasswordChangeForm):
+    pass
+
+
+class SetPasswordForm(SetPasswordMixin, authforms.SetPasswordForm):
+    pass
 
 
 def organisation_choices():

--- a/lizard_auth_server/signal_handlers.py
+++ b/lizard_auth_server/signal_handlers.py
@@ -1,7 +1,25 @@
+from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.db.models.signals import post_save
+from django.db.models.signals import pre_save
 from django.dispatch import receiver
+from lizard_auth_server.backends import CognitoUser
 from lizard_auth_server.models import UserProfile
+
+
+# Have the creation of a User fail if it exists in Cognito
+@receiver(pre_save, sender=User)
+def check_user_exists(sender, instance, **kwargs):
+    if not getattr(settings, "AWS_ACCESS_KEY_ID", None):
+        return  # do nothing if AWS is not configured
+
+    if instance.pk is not None:
+        return  # do nothing if it is an update to an existing user
+
+    cognito_user = CognitoUser.from_username(instance.username)
+    if cognito_user.admin_user_exists():
+        raise ValidationError("This username is already taken.")
 
 
 # Have the creation of a User trigger the creation of a UserProfile.

--- a/lizard_auth_server/templates/lizard_auth_server/edit_profile.html
+++ b/lizard_auth_server/templates/lizard_auth_server/edit_profile.html
@@ -4,23 +4,16 @@
 {% block subtitle %}{% trans 'Edit profile' %}{% endblock %}
 
 {% block container %}
-<div class="content">
-    {% if form.errors %}
-        <div class="alert alert-block fade in">
-            <a class="close" data-dismiss="alert" href="#">×</a>
-            <p>{% blocktrans count form.errors.items|length as counter %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktrans %}</p>
-        </div>
-    {% endif %}
-    <form action="" method="post">{% csrf_token %}
-        <fieldset>
-            <legend>{% trans 'Edit profile' %}</legend>
-            {% for field in form %}
-                {% include 'lizard_auth_server/form_field.html' %}
-            {% endfor %}
-            <div class="actions">
-                <input type="submit" class="btn btn-primary" value="{% trans 'Submit changes' %}">&nbsp;<button type="reset" class="btn">{% trans 'Reset values' %}</button>
-            </div>
-        </fieldset>
-    </form>
-</div>
+    <div class="content">
+        <p>
+            Het bewerken van uw profiel is momenteel niet beschikbaar door een overgang naar een nieuw inlogsysteem.
+        </p>
+        <p>
+            Editing profiles is currently unavailable due to a transition to a new user authentication system.
+        </p>
+        <p>
+            {% url "index" as index_url %}
+            <a href="{{ index_url }}">{% trans "Back to the home page" %}</a>
+        </p>
+    </div>
 {% endblock %}

--- a/lizard_auth_server/tests/test_backends.py
+++ b/lizard_auth_server/tests/test_backends.py
@@ -1,7 +1,8 @@
 """Mostly copied from django-warrant's tests.py."""
 
 from django.conf import settings
-from django.test import TestCase, override_settings
+from django.test import override_settings
+from django.test import TestCase
 from lizard_auth_server import backends
 from unittest import mock
 

--- a/lizard_auth_server/tests/test_backends.py
+++ b/lizard_auth_server/tests/test_backends.py
@@ -8,9 +8,9 @@ from django.http import HttpRequest
 from django.test import override_settings
 from django.test import TestCase
 from importlib import import_module
+from lizard_auth_server import backends
 from mock import patch
 from warrant import Cognito
-from lizard_auth_server import backends
 
 
 def get_user(cls, *args, **kwargs):
@@ -48,6 +48,7 @@ def get_user(cls, *args, **kwargs):
         metadata=user_metadata,
     )
 
+
 @override_settings(
     AUTHENTICATION_BACKENDS=[
         "lizard_auth_server.backends.CognitoBackend",
@@ -55,7 +56,6 @@ def get_user(cls, *args, **kwargs):
     ],
 )
 class TestCognitoUser(TestCase):
-
     @patch("lizard_auth_server.backends.CognitoUser.__init__")
     def test_smoke(self, patched_init):
         """Quick test
@@ -88,9 +88,13 @@ class TestCognitoUser(TestCase):
         }
         attribute_list = example_user["UserAttributes"]
         cognito_user = backends.CognitoUser()
-        django_user1 = cognito_user.get_user_obj(username="test", attribute_list=attribute_list)
+        django_user1 = cognito_user.get_user_obj(
+            username="test", attribute_list=attribute_list
+        )
         self.assertEqual(django_user1.email, "test@email.com")
         self.assertTrue(django_user1.user_profile.migrated_at)
         # Doing it a second time reuses the exisiting user.
-        django_user2 = cognito_user.get_user_obj(username="test", attribute_list=attribute_list)
+        django_user2 = cognito_user.get_user_obj(
+            username="test", attribute_list=attribute_list
+        )
         self.assertEqual(django_user2.id, django_user1.id)

--- a/lizard_auth_server/tests/test_backends.py
+++ b/lizard_auth_server/tests/test_backends.py
@@ -1,16 +1,9 @@
 """Mostly copied from django-warrant's tests.py."""
 
-from botocore.exceptions import ClientError
 from django.conf import settings
-from django.contrib.auth import authenticate as django_authenticate
-from django.contrib.auth import get_user_model
-from django.http import HttpRequest
-from django.test import override_settings
 from django.test import TestCase
-from importlib import import_module
 from lizard_auth_server import backends
 from unittest import mock
-from warrant import Cognito
 
 
 def get_user(cls, *args, **kwargs):

--- a/lizard_auth_server/tests/test_forms.py
+++ b/lizard_auth_server/tests/test_forms.py
@@ -1,8 +1,53 @@
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+from django.test import override_settings
 from django.test import TestCase
 from lizard_auth_server.forms import JWTDecryptForm
+from lizard_auth_server.forms import SetPasswordMixin
+from unittest import mock
 
 
 class TestForm(TestCase):
     def test_smoke(self):
         jwtform = JWTDecryptForm()
         self.assertTrue(jwtform is not None)
+
+
+@override_settings(AWS_ACCESS_KEY_ID="something")
+class TestSetPasswordMixin(TestCase):
+    def setUp(self):
+        # self.user = User.objects.create(username="testuser")
+        # self.user.set_password("pwd")
+
+        self.form = SetPasswordMixin()
+        self.form.cleaned_data = {}
+        self.form.error_messages = {"password_incorrect": "bla"}
+        self.form.user = User(username="testuser")
+
+    @mock.patch("lizard_auth_server.forms.CognitoBackend")
+    def test_clean_old_password_correct(self, CognitoBackend_m):
+        # Simulate successful authentication with old_password
+        authenticate = CognitoBackend_m.return_value.authenticate
+        authenticate.return_value = User()
+        self.form.cleaned_data["old_password"] = "correct"
+
+        self.assertEqual("correct", self.form.clean_old_password())
+
+        self.assertDictEqual(
+            {"username": "testuser", "password": "correct"},
+            authenticate.call_args[1],
+        )
+
+    @mock.patch("lizard_auth_server.forms.CognitoBackend")
+    def test_clean_old_password_wrong(self, CognitoBackend_m):
+        # Simulate successful authentication with old_password
+        authenticate = CognitoBackend_m.return_value.authenticate
+        authenticate.return_value = None
+        self.form.cleaned_data["old_password"] = "wrong"
+
+        self.assertRaises(ValidationError, self.form.clean_old_password)
+
+        self.assertDictEqual(
+            {"username": "testuser", "password": "wrong"},
+            authenticate.call_args[1],
+        )

--- a/lizard_auth_server/urls.py
+++ b/lizard_auth_server/urls.py
@@ -206,14 +206,36 @@ urlpatterns = [
     # Override django-auth's password change URLs
     url(
         r"^password_change/$",
-        views.ChangePasswordView.as_view(),
+        auth_views.password_change,
+        kwargs={
+            "template_name": "lizard_auth_server/password_change_form.html",
+            "password_change_form": forms.PasswordChangeForm,
+        },
         name="password_change",
+    ),
+    url(
+        r"^password_change/done/$",
+        auth_views.password_change_done,
+        kwargs={"template_name": "lizard_auth_server/password_change_done.html"},
+        name="password_change_done",
     ),
     # Override django-auth's password reset URLs
     url(
         r"^password_reset/$",
-        views.ChangePasswordView.as_view(),
+        auth_views.password_reset,
+        kwargs={
+            "template_name": "lizard_auth_server/password_reset_form.html",
+            "email_template_name": "lizard_auth_server/password_reset_email.html",
+            "subject_template_name": "lizard_auth_server/password_reset_subject.txt"
+            # TODO can't configure email language somehow
+        },
         name="password_reset",
+    ),
+    url(
+        r"^password_reset/done/$",
+        auth_views.password_reset_done,
+        kwargs={"template_name": "lizard_auth_server/password_reset_done.html"},
+        name="password_reset_done",
     ),
     url(
         r"^reset/(?P<uidb64>[0-9A-Za-z]{1,13})-"

--- a/lizard_auth_server/urls.py
+++ b/lizard_auth_server/urls.py
@@ -206,36 +206,14 @@ urlpatterns = [
     # Override django-auth's password change URLs
     url(
         r"^password_change/$",
-        auth_views.password_change,
-        kwargs={
-            "template_name": "lizard_auth_server/password_change_form.html",
-            "password_change_form": forms.PasswordChangeForm,
-        },
+        views.ChangePasswordView.as_view(),
         name="password_change",
-    ),
-    url(
-        r"^password_change/done/$",
-        auth_views.password_change_done,
-        kwargs={"template_name": "lizard_auth_server/password_change_done.html"},
-        name="password_change_done",
     ),
     # Override django-auth's password reset URLs
     url(
         r"^password_reset/$",
-        auth_views.password_reset,
-        kwargs={
-            "template_name": "lizard_auth_server/password_reset_form.html",
-            "email_template_name": "lizard_auth_server/password_reset_email.html",
-            "subject_template_name": "lizard_auth_server/password_reset_subject.txt"
-            # TODO can't configure email language somehow
-        },
+        views.ChangePasswordView.as_view(),
         name="password_reset",
-    ),
-    url(
-        r"^password_reset/done/$",
-        auth_views.password_reset_done,
-        kwargs={"template_name": "lizard_auth_server/password_reset_done.html"},
-        name="password_reset_done",
     ),
     url(
         r"^reset/(?P<uidb64>[0-9A-Za-z]{1,13})-"

--- a/lizard_auth_server/views.py
+++ b/lizard_auth_server/views.py
@@ -147,45 +147,38 @@ class AccessToPortalView(TemplateView):
         return self.profile.all_organisation_roles(self.portal)
 
 
-class EditProfileView(FormView):
+class EditProfileView(TemplateView):
     """
-    Straightforward view which displays a form to have a user
-    edit his / her own profile.
+    Display a message that this view is now unavailable.
     """
 
-    template_name = "lizard_auth_server/edit_profile.html"
-    form_class = forms.EditProfileForm
-    _profile = None
+    template_name = "lizard_auth_server/error_message.html"
 
-    @method_decorator(login_required)
-    def dispatch(self, request, *args, **kwargs):
-        return super(EditProfileView, self).dispatch(request, *args, **kwargs)
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context["error_message"] = (
+            "Editing profiles is currently unavailable due to a transition to "
+            "a new user authentication system. Please contact "
+            "servicedesk@nelen-schuurmans.nl for changing your email or name."
+        )
+        return context
 
-    @property
-    def profile(self):
-        if not self._profile:
-            self._profile = self.request.user.user_profile
-        return self._profile
 
-    def get_initial(self):
-        return {
-            "email": self.profile.email,
-            "first_name": self.profile.first_name,
-            "last_name": self.profile.last_name,
-        }
+class ChangePasswordView(TemplateView):
+    """
+    Display a message that this view is now unavailable.
+    """
 
-    def get_form(self, form_class=None):
-        if form_class is None:
-            form_class = self.get_form_class()
-        return form_class(user=self.request.user, **self.get_form_kwargs())
+    template_name = "lizard_auth_server/error_message.html"
 
-    def form_valid(self, form):
-        data = form.cleaned_data
-
-        # let the model handle the rest
-        self.profile.update_all(data)
-
-        return HttpResponseRedirect(reverse("profile"))
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context["error_message"] = (
+            "Changing password is currently unavailable due to a transition "
+            " to a new user authentication system. Please contact "
+            "servicedesk@nelen-schuurmans.nl for a password reset."
+        )
+        return context
 
 
 class InviteUserView(StaffOnlyMixin, FormView):

--- a/lizard_auth_server/views.py
+++ b/lizard_auth_server/views.py
@@ -164,23 +164,6 @@ class EditProfileView(TemplateView):
         return context
 
 
-class ChangePasswordView(TemplateView):
-    """
-    Display a message that this view is now unavailable.
-    """
-
-    template_name = "lizard_auth_server/error_message.html"
-
-    def get_context_data(self, *args, **kwargs):
-        context = super().get_context_data(*args, **kwargs)
-        context["error_message"] = (
-            "Changing password is currently unavailable due to a transition "
-            " to a new user authentication system. Please contact "
-            "servicedesk@nelen-schuurmans.nl for a password reset."
-        )
-        return context
-
-
 class InviteUserView(StaffOnlyMixin, FormView):
     template_name = "lizard_auth_server/invite_user.html"
     form_class = forms.InviteUserForm

--- a/lizard_auth_server/views.py
+++ b/lizard_auth_server/views.py
@@ -152,16 +152,7 @@ class EditProfileView(TemplateView):
     Display a message that this view is now unavailable.
     """
 
-    template_name = "lizard_auth_server/error_message.html"
-
-    def get_context_data(self, *args, **kwargs):
-        context = super().get_context_data(*args, **kwargs)
-        context["error_message"] = (
-            "Editing profiles is currently unavailable due to a transition to "
-            "a new user authentication system. Please contact "
-            "servicedesk@nelen-schuurmans.nl for changing your email or name."
-        )
-        return context
+    template_name = "lizard_auth_server/edit_profile.html"
 
 
 class InviteUserView(StaffOnlyMixin, FormView):

--- a/lizard_auth_server/views_api_v2.py
+++ b/lizard_auth_server/views_api_v2.py
@@ -8,7 +8,6 @@ from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.core.mail import send_mail
 from django.db import transaction
-from django.db.models import Q
 from django.http import HttpResponse
 from django.http import HttpResponseBadRequest
 from django.http import HttpResponseNotFound


### PR DESCRIPTION
This PR covers three different things:

- Edit_profile is not possible anymore. It shows a message telling you that.
- Forgot/change password now changes the password in Cognito. We wanted to keep the forgot password flow working. It also checks the old_password with Cognito.
- Creation of users that exist in cognito already is prevented (issue described in https://github.com/nens/sso/pull/23). I saw an easy way to make it.
